### PR TITLE
bugfix: bad row handling for unicode characters

### DIFF
--- a/node.lua
+++ b/node.lua
@@ -108,7 +108,7 @@ local Display = function(display_cols, display_rows, style_name)
 
     local current = 1
     local function append(line)
-        line = line:sub(1, display_cols)
+        line = utf8.sub(line, 1, display_cols)
         rows[current].set(line)
         current = current + 1
         if current > #rows then


### PR DESCRIPTION
I have added a new language to the package. I've noticed a strange behaviour: for each non-ascii character (more than 1 byte of UTF8) I was getting a space at the end of the line that contained the character(s).
The reason was that `line:sub` is counting bytes, not characters.

P.S. I don't mind contributing the new language (Polish, probably mildly useful) but with the additional tweak that I have reversed the digits so they are going from 9 to 0 which makes the countdown look better. Do you want a pull request like that?